### PR TITLE
Side effects when save translations

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -108,17 +108,15 @@ trait Translatable
      */
     public function saveTranslations(array $translations)
     {
-        $backup = $this->getLocale();
         $success = true;
 
         foreach($translations as $locale => $attributes) {
-            $this->setLocale($locale);
-            $this->fill($attributes);
+            $model = $this->fresh();
+            $model->setLocale($locale);
+            $model->fill($attributes);
 
-            $success &= $this->save();
+            $success &= $model->save();
         }
-
-        $this->setLocale($backup);
 
         return $success;
     }

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -25,6 +25,7 @@ abstract class IntegrationTestCase extends TestCase
 
         $this->schema()->create('posts', function (Blueprint $table) {
             $table->increments('id');
+            $table->string('image')->nullable();
             $table->timestamps();
         });
 

--- a/tests/TestCRUD.php
+++ b/tests/TestCRUD.php
@@ -133,6 +133,46 @@ class TestCRUD extends IntegrationTestCase
         $this->assertEquals('Lorem ipsum FR', User::translateInto('fr')->first()->bio);
     }
 
+    public function testSaveTranslationWithoutSideEffectsDependingOrderOperations()
+    {
+        Post::forceCreate([]);
+
+        $post = Post::first();
+        $post->forceSaveTranslation('de', ['title' => 'Title DE']);
+        $post->forceSaveTranslation('fr', ['title' => 'Title FR']);
+        $post->forceSaveTranslation('de', ['body' => 'Body DE']);
+        $post->forceSaveTranslation('fr', ['body' => 'Body FR']);
+
+        $this->assertEquals('Title DE', Post::translateInto('de')->first()->title);
+        $this->assertEquals('Body DE', Post::translateInto('de')->first()->body);
+        $this->assertEquals('Title FR', Post::translateInto('fr')->first()->title);
+        $this->assertEquals('Body FR', Post::translateInto('fr')->first()->body);
+    }
+
+    public function testSaveTranslationWithoutSideEffectsWhenUpdateModel()
+    {
+        Post::forceCreate([]);
+
+        $post = Post::first();
+
+        $post->forceSaveTranslation('en', [
+            'title' => 'Title EN v2',
+            'body' => 'Body EN v2',
+        ]);
+        $post->forceSaveTranslation('de', [
+            'title' => 'Title DE v2',
+            'body' => 'Body DE v2',
+        ]);
+
+        $post->update(['image' => 'blog_cover.png']);
+
+        $this->assertEquals('Title DE v2', Post::translateInto('de')->first()->title);
+        $this->assertEquals('Body DE v2', Post::translateInto('de')->first()->body);
+        $this->assertEquals('Title EN v2', Post::translateInto('en')->first()->title);
+        $this->assertEquals('Body EN v2', Post::translateInto('en')->first()->body);
+        $this->assertEquals('blog_cover.png', Post::first()->image);
+    }
+
     public function testWhereTranslated()
     {
         Post::forceCreate(['title' => 'Title 1']);

--- a/tests/stubs/Post.php
+++ b/tests/stubs/Post.php
@@ -8,6 +8,7 @@ class Post extends Model
     use Translatable;
 
     protected $translatable = ['title', 'body'];
+    protected $fillable = ['image'];
 
     public function user()
     {


### PR DESCRIPTION
When I save some translations or update the model some translations are lost because some weird side effect. I just wrote some tests where you can see the problem and also I wrote a solution about it.

If you want test without the solution to see the problem, merge only the commit with the tests.

By the way, cool package :)