### PR TITLE
Side effects when use fillable

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -111,7 +111,7 @@ trait Translatable
         $success = true;
 
         foreach($translations as $locale => $attributes) {
-            $model = clone $this;
+            $model = $this->fresh();
             $model->setLocale($locale);
             $model->fill($attributes);
 

--- a/tests/TestCRUD.php
+++ b/tests/TestCRUD.php
@@ -133,6 +133,23 @@ class TestCRUD extends IntegrationTestCase
         $this->assertEquals('Lorem ipsum FR', User::translateInto('fr')->first()->bio);
     }
 
+    public function testSaveTranslationWithoutSideEffectsWhenUseFillable()
+    {
+        Post::forceCreate([]);
+
+        $post = Post::first();
+        $post->forceSaveTranslation('de', ['title' => 'Title DE']);
+        $post->title = 'Title EN';
+        $post->body = 'Body EN';
+        $post->save();
+        $post->forceSaveTranslation('de', ['body' => 'Body DE']);
+
+        $this->assertEquals('Title EN', Post::translateInto('en')->first()->title);
+        $this->assertEquals('Body EN', Post::translateInto('en')->first()->body);
+        $this->assertEquals('Title DE', Post::translateInto('de')->first()->title);
+        $this->assertEquals('Body DE', Post::translateInto('de')->first()->body);
+    }
+
     public function testSaveTranslationWithoutSideEffectsDependingOrderOperations()
     {
         Post::forceCreate([]);

--- a/tests/stubs/Post.php
+++ b/tests/stubs/Post.php
@@ -8,6 +8,7 @@ class Post extends Model
     use Translatable;
 
     protected $translatable = ['title', 'body'];
+    protected $fillable = ['title', 'body'];
 
     public function user()
     {


### PR DESCRIPTION
I'm not sure that clone the model is a good option when save translations. For me looks like the methods "saveTranslation/forceSaveTranslations" must save only the attributes from the parameter list instead of the model.

Of course, get a fresh model is not the ideal solution because an unnecessary request to the DB every time you save a translation.