### PR TITLE
Add support for Postgresql

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
+use Illuminate\Database\Query\Grammars\SQLiteGrammar;
 use Illuminate\Database\Query\Grammars\PostgresGrammar;
 use Illuminate\Database\Query\Grammars\SqlServerGrammar;
 
@@ -277,7 +278,7 @@ class QueryBuilder extends Builder
     {
         if ($this->grammar instanceof SqlServerGrammar) {
             $ifNull = 'isnull';
-        } elseif ($this->grammar instanceof MySqlGrammar) {
+        } elseif ($this->grammar instanceof MySqlGrammar || $this->grammar instanceof SQLiteGrammar) {
             $ifNull = 'ifnull';
         } elseif ($this->grammar instanceof PostgresGrammar) {
             $ifNull = 'coalesce';

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -6,7 +6,10 @@ use InvalidArgumentException;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
+use Illuminate\Database\Query\Grammars\PostgresGrammar;
 use Illuminate\Database\Query\Grammars\SqlServerGrammar;
+
 
 class QueryBuilder extends Builder
 {
@@ -272,7 +275,15 @@ class QueryBuilder extends Builder
      */
     public function compileIfNull($primary, $fallback, $alias = null)
     {
-        $ifNull = $this->grammar instanceof SqlServerGrammar ? 'isnull' : 'ifnull';
+        if ($this->grammar instanceof SqlServerGrammar) {
+            $ifNull = 'isnull';
+        } elseif ($this->grammar instanceof MySqlGrammar) {
+            $ifNull = 'ifnull';
+        } elseif ($this->grammar instanceof PostgresGrammar) {
+            $ifNull = 'coalesce';
+        } else {
+            throw new \Exception('Cannot compile IFNULL statement for grammar ' . get_class($this->grammar));
+        }
 
         $primary = $this->grammar->wrap($primary);
         $fallback = $this->grammar->wrap($fallback);


### PR DESCRIPTION
Basically all of the postgres specific syntax is handled by laravel itself. The only exception is the `compileIfNull` method which compiles an ifnull/isnull statement which assumed that MySql syntax is used if the database is not SqlServer.

This implementation
- Uses `isnull` for SqlServer
- Uses `ifnull` for MySql
- Uses `coalesce` for Postgres
- Throws an exception if the currently used grammar is neither of the three (instead of continuing with SQL that may or may not be correct)