### PR TITLE
optimize translate method if locale is current

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -233,7 +233,11 @@ trait Translatable
      */
     public function translate($locale)
     {
-        $found = $this->translations->where($this->getLocaleKey(), $locale)->first();
+        if (app()->getLocale() == $locale) {
+            $found = $this;
+        } else {
+            $found = $this->translations->where($this->getLocaleKey(), $locale)->first();
+        }
 
         if (!$found && $this->shouldFallback($locale)) {
             return $this->translate($this->getFallbackLocale());

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -281,6 +281,7 @@ trait Translatable
     public function translationModel()
     {
         $translation = new TranslationModel();
+        $translation->setConnection($this->getI18nConnection());
         $translation->setTable($this->getI18nTable());
         $translation->setKeyName($this->getForeignKey());
         $translation->setLocaleKey($this->getLocaleKey());
@@ -440,6 +441,16 @@ trait Translatable
         }
 
         return TranslatableConfig::withFallback();
+    }
+
+    /**
+     * Get the i18n connection name associated with the model.
+     *
+     * @return string
+     */
+    public function getI18nConnection()
+    {
+        return $this->getConnectionName();
     }
 
     /**


### PR DESCRIPTION
Remove the extra query if translated version is generated